### PR TITLE
Transfer Signing and UI Updates

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,11 @@
 [context.production.environment]
   REACT_APP_COSMOS_URL = "https://kava3.data.kava.io"
+  REACT_APP_CHAIN_ID = "kava3"
 
 [context.deploy-preview.environment]
-  REACT_APP_COSMOS_URL = "https://kava3.data.kava.io"
+  REACT_APP_COSMOS_URL = "http://35.193.236.181"
+  REACT_APP_CHAIN_ID = "testing"
 
 [context.branch-deploy.environment]
-  REACT_APP_COSMOS_URL = "https://kava3.data.kava.io"
+  REACT_APP_COSMOS_URL = "http://35.193.236.181"
+  REACT_APP_CHAIN_ID = "testing"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,62 +1347,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@kava-labs/javascript-sdk": {
-      "version": "2.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@kava-labs/javascript-sdk/-/javascript-sdk-2.0.0-beta.6.tgz",
-      "integrity": "sha512-OvXSAuJ5inHLWJ++8mZIdBs5UNKooixPg48rFPJ9Y2r1wYQcfDQsnr5Rbs+ROKkmiC0RdYuRo4/pjEXcA8Jrug==",
-      "requires": {
-        "@kava-labs/sig": "^0.1.0",
-        "axios": "^0.19.2",
-        "bech32": "^1.1.3",
-        "big.js": "^5.2.2",
-        "bip39": "^3.0.2",
-        "crypto-js": "^4.0.0",
-        "lodash": "^4.17.15",
-        "url": "^0.11.0"
-      }
-    },
-    "@kava-labs/sig": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@kava-labs/sig/-/sig-0.1.0.tgz",
-      "integrity": "sha512-LvVW0aL8Z4yZzDh2yxYUBluwJfpIX2W6unbFDpKR+roB8axBXWz9hiDZiYzGMPbwQUiCGu91C0p4gqOy679Jcg==",
-      "requires": {
-        "@tendermint/belt": "0.2.1",
-        "@tendermint/types": "0.1.1",
-        "bech32": "1.1.3",
-        "bip32": "2.0.4",
-        "bip39": "3.0.2",
-        "create-hash": "1.2.0",
-        "secp256k1": "3.7.1"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-          "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
-        },
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "secp256k1": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.4.1",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
-      }
-    },
     "@ledgerhq/devices": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.17.0.tgz",
@@ -1454,34 +1398,6 @@
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.17.0.tgz",
       "integrity": "sha512-cY3aL9hLdQONFJihQDaO3szmyo53nLdMYisVLfjxJ2SBH5SOyoAtg6Utwz4u6Y3Cf464BJ0wZu3/SlVO0kboBQ=="
-    },
-    "@lunie/cosmos-api": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@lunie/cosmos-api/-/cosmos-api-0.2.5.tgz",
-      "integrity": "sha512-4p2lNr1ByYeVGGQwKkp+BdK8fI5yZwOYNoDfFSOpJ80ybQeOF8ox5jTRZrWOetEP47fqBZA0Gv5jt5tTtJWW2A==",
-      "requires": {
-        "@babel/runtime": "^7.5.4",
-        "axios": "^0.19.0"
-      }
-    },
-    "@lunie/cosmos-keys": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@lunie/cosmos-keys/-/cosmos-keys-0.2.3.tgz",
-      "integrity": "sha512-xuGlh5DD2of0WJCVosx5DgTaReBpqsuicaRECfMw7aZwEDN8HHOR2lCAH2EnRksBCVCAi6MG5ib6l/d6dj3TbQ==",
-      "requires": {
-        "bcrypto": "^5.1.0",
-        "bech32": "^1.1.3",
-        "bip32": "^2.0.4",
-        "bip39": "^3.0.2",
-        "crypto-js": "^3.1.9-1"
-      },
-      "dependencies": {
-        "crypto-js": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-          "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
-        }
-      }
     },
     "@lunie/cosmos-ledger": {
       "version": "0.1.8",
@@ -1743,17 +1659,17 @@
       }
     },
     "@tendermint/belt": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tendermint/belt/-/belt-0.2.1.tgz",
-      "integrity": "sha512-Z3byTEpbSfrMaNx431pr8P4nrFshWz7WiFqxv/cTVgRENCVfndygOz0W15qC1pgqBhhnQPLEnmdP/GIyiS7JWg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tendermint/belt/-/belt-0.3.0.tgz",
+      "integrity": "sha512-3ZIsrbh9HLGM8cFyptK5iBeWou30srDiBjY8cVXFkz8aqPprt0OT7T9JqiqoG570x1pB0xiKwDDBxtQ120Gxug==",
       "requires": {
-        "@tendermint/types": "0.1.1"
+        "@tendermint/types": "0.1.2"
       }
     },
     "@tendermint/types": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tendermint/types/-/types-0.1.1.tgz",
-      "integrity": "sha512-jMEz5tJ3ncA8903N2DoPD6EJawSyORRSyWvQbmxyz8ONiugjOKvoesMzz/xIioe1Ekzf6YJnw/3RI+kT9qdNyg=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@tendermint/types/-/types-0.1.2.tgz",
+      "integrity": "sha512-VTYYB5xj6jRS0FnJWaSTuDBYOrXXxz1T23tJHuCkK2VGAqHOwaNHrtUK+fKSaYIoCDr21JM0S+uGej5Toqw1aQ=="
     },
     "@testing-library/dom": {
       "version": "6.16.0",
@@ -2737,37 +2653,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -3280,14 +3165,6 @@
         }
       }
     },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -3304,15 +3181,6 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
-      }
-    },
-    "bcrypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.2.0.tgz",
-      "integrity": "sha512-yy+kDrUG6aXP7NIYq7kKIwlrXtx/51488IGfuqhyM6FYF8zNI1mPRwvAPvQ1RfE5e7WW7fVdZt4yHlmN4HJ4Hg==",
-      "requires": {
-        "bufio": "~1.0.7",
-        "loady": "~0.0.1"
       }
     },
     "bech32": {
@@ -3334,55 +3202,9 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip32": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.4.tgz",
-      "integrity": "sha512-ioPytarPDIrWckWMuK4RNUtvwhvWEc2fvuhnO0WEwu732k5OLjUXv4rXi2c/KJHw9ZMNQMkYRJrBw81RujShGQ==",
-      "requires": {
-        "@types/node": "10.12.18",
-        "bs58check": "^2.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.1.0",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.12.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
-        }
-      }
-    },
-    "bip39": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        }
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "bluebird": {
@@ -3608,24 +3430,6 @@
         "pkg-up": "^2.0.0"
       }
     },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3633,6 +3437,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -3658,11 +3467,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "bufio": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -4371,11 +4175,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
-    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -5063,16 +4862,6 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -5126,6 +4915,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",
+      "integrity": "sha512-wmtrUGyfSC23GC/B1SMv2ogAUgbQEtDmTIhfqielrG5ExIM9TP4UoYdi90jLF1aTcsWCJNEO0UrgKzP0y3nTSg==",
+      "requires": {
+        "jake": "^10.6.1"
+      }
     },
     "electron-to-chromium": {
       "version": "1.3.480",
@@ -6113,7 +5910,16 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
+    "filelist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
+      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "filesize": {
       "version": "6.0.1",
@@ -7488,6 +7294,24 @@
         "html-escaper": "^2.0.0"
       }
     },
+    "jake": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
+    },
     "jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
@@ -8432,11 +8256,6 @@
         }
       }
     },
-    "loady": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.1.tgz",
-      "integrity": "sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw=="
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -8926,7 +8745,8 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12427,6 +12247,174 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-explorer": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.4.2.tgz",
+      "integrity": "sha512-3ECQLffCFV8QgrTqcmddLkWL4/aQs6ljYfgWCLselo5QtizOfOeUCKnS4rFn7MIrdeZLM6TZrseOtsrWZhWKoQ==",
+      "requires": {
+        "btoa": "^1.2.1",
+        "chalk": "^3.0.0",
+        "convert-source-map": "^1.7.0",
+        "ejs": "^3.0.2",
+        "escape-html": "^1.0.3",
+        "glob": "^7.1.6",
+        "gzip-size": "^5.1.1",
+        "lodash": "^4.17.15",
+        "open": "^7.0.3",
+        "source-map": "^0.7.3",
+        "temp": "^0.9.1",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -12956,6 +12944,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
+    "temp": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
+      "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+      "requires": {
+        "rimraf": "~2.6.2"
+      }
+    },
     "terser": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -13164,25 +13160,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
-    "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "bn.js": "^4.11.8",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.4.0",
-        "nan": "^2.13.2"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
-      }
-    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -13328,11 +13305,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -14335,14 +14307,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "requires": {
-        "bs58check": "<3.0.0"
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,6 +1347,62 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@kava-labs/javascript-sdk": {
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@kava-labs/javascript-sdk/-/javascript-sdk-2.0.0-beta.6.tgz",
+      "integrity": "sha512-OvXSAuJ5inHLWJ++8mZIdBs5UNKooixPg48rFPJ9Y2r1wYQcfDQsnr5Rbs+ROKkmiC0RdYuRo4/pjEXcA8Jrug==",
+      "requires": {
+        "@kava-labs/sig": "^0.1.0",
+        "axios": "^0.19.2",
+        "bech32": "^1.1.3",
+        "big.js": "^5.2.2",
+        "bip39": "^3.0.2",
+        "crypto-js": "^4.0.0",
+        "lodash": "^4.17.15",
+        "url": "^0.11.0"
+      }
+    },
+    "@kava-labs/sig": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@kava-labs/sig/-/sig-0.1.0.tgz",
+      "integrity": "sha512-LvVW0aL8Z4yZzDh2yxYUBluwJfpIX2W6unbFDpKR+roB8axBXWz9hiDZiYzGMPbwQUiCGu91C0p4gqOy679Jcg==",
+      "requires": {
+        "@tendermint/belt": "0.2.1",
+        "@tendermint/types": "0.1.1",
+        "bech32": "1.1.3",
+        "bip32": "2.0.4",
+        "bip39": "3.0.2",
+        "create-hash": "1.2.0",
+        "secp256k1": "3.7.1"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
+          "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "secp256k1": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.4.1",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
+    },
     "@ledgerhq/devices": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.17.0.tgz",
@@ -1450,6 +1506,26 @@
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0",
         "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
       }
     },
     "@material-ui/styles": {
@@ -1646,6 +1722,19 @@
         "@svgr/plugin-svgo": "^4.3.1",
         "loader-utils": "^1.2.3"
       }
+    },
+    "@tendermint/belt": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tendermint/belt/-/belt-0.2.1.tgz",
+      "integrity": "sha512-Z3byTEpbSfrMaNx431pr8P4nrFshWz7WiFqxv/cTVgRENCVfndygOz0W15qC1pgqBhhnQPLEnmdP/GIyiS7JWg==",
+      "requires": {
+        "@tendermint/types": "0.1.1"
+      }
+    },
+    "@tendermint/types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tendermint/types/-/types-0.1.1.tgz",
+      "integrity": "sha512-jMEz5tJ3ncA8903N2DoPD6EJawSyORRSyWvQbmxyz8ONiugjOKvoesMzz/xIioe1Ekzf6YJnw/3RI+kT9qdNyg=="
     },
     "@testing-library/dom": {
       "version": "6.16.0",
@@ -3172,6 +3261,14 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -3209,9 +3306,55 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.4.tgz",
+      "integrity": "sha512-ioPytarPDIrWckWMuK4RNUtvwhvWEc2fvuhnO0WEwu732k5OLjUXv4rXi2c/KJHw9ZMNQMkYRJrBw81RujShGQ==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+      }
+    },
+    "bip39": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "bluebird": {
@@ -3435,6 +3578,24 @@
         "electron-to-chromium": "^1.3.413",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "bser": {
@@ -4177,6 +4338,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -4863,6 +5029,16 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -5904,8 +6080,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
       "version": "6.0.1",
@@ -8713,8 +8888,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12952,6 +13126,25 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-secp256k1": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        }
+      }
+    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -13097,6 +13290,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -14099,6 +14297,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,6 +1464,25 @@
         "axios": "^0.19.0"
       }
     },
+    "@lunie/cosmos-keys": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@lunie/cosmos-keys/-/cosmos-keys-0.2.3.tgz",
+      "integrity": "sha512-xuGlh5DD2of0WJCVosx5DgTaReBpqsuicaRECfMw7aZwEDN8HHOR2lCAH2EnRksBCVCAi6MG5ib6l/d6dj3TbQ==",
+      "requires": {
+        "bcrypto": "^5.1.0",
+        "bech32": "^1.1.3",
+        "bip32": "^2.0.4",
+        "bip39": "^3.0.2",
+        "crypto-js": "^3.1.9-1"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+          "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+        }
+      }
+    },
     "@lunie/cosmos-ledger": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@lunie/cosmos-ledger/-/cosmos-ledger-0.1.8.tgz",
@@ -3287,6 +3306,15 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bcrypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.2.0.tgz",
+      "integrity": "sha512-yy+kDrUG6aXP7NIYq7kKIwlrXtx/51488IGfuqhyM6FYF8zNI1mPRwvAPvQ1RfE5e7WW7fVdZt4yHlmN4HJ4Hg==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.1"
+      }
+    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -3630,6 +3658,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -8398,6 +8431,11 @@
           }
         }
       }
+    },
+    "loady": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.1.tgz",
+      "integrity": "sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw=="
     },
     "locate-path": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@kava-labs/javascript-sdk": "^2.0.0-beta.6",
     "@lunie/cosmos-api": "^0.2.5",
+    "@lunie/cosmos-keys": "^0.2.3",
     "@lunie/cosmos-ledger": "^0.1.8",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
@@ -14,6 +15,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "fontsource-roboto": "^2.1.4",
+    "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@kava-labs/javascript-sdk": "^2.0.0-beta.6",
     "@lunie/cosmos-api": "^0.2.5",
     "@lunie/cosmos-ledger": "^0.1.8",
     "@material-ui/core": "^4.10.2",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -3,23 +3,21 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@kava-labs/javascript-sdk": "^2.0.0-beta.6",
-    "@lunie/cosmos-api": "^0.2.5",
-    "@lunie/cosmos-keys": "^0.2.3",
     "@lunie/cosmos-ledger": "^0.1.8",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@reduxjs/toolkit": "^1.4.0",
+    "@tendermint/belt": "^0.3.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "fontsource-roboto": "^2.1.4",
-    "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "source-map-explorer": "^2.4.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -9,10 +9,10 @@ import { Loading } from './features/common/Loading';
 import { CosmosAPI } from './features/api/CosmosAPI';
 import { APIConnect } from './features/api/APIConnect';
 import logo from './logo.svg';
-import { COSMOS_URL } from './config';
+import { COSMOS_URL, CHAIN_ID } from './config';
 
 const ledger = new CosmosLedger();
-const cosmosAPI = new CosmosAPI(COSMOS_URL, ledger);
+const cosmosAPI = new CosmosAPI(COSMOS_URL, CHAIN_ID, ledger);
 
 const useStyles = makeStyles({
   root: {

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ let cosmosURL;
 if (process.env.REACT_APP_COSMOS_URL) {
   cosmosURL = process.env.REACT_APP_COSMOS_URL;
 } else {
-  cosmosURL = 'http://127.0.0.1:1317';
+  cosmosURL = 'http://35.193.236.181';
 }
 
 export const COSMOS_URL = cosmosURL;

--- a/src/config.js
+++ b/src/config.js
@@ -14,3 +14,5 @@ if (process.env.REACT_APP_COSMOS_URL) {
 }
 
 export const COSMOS_URL = cosmosURL;
+
+export const CHAIN_ID = 'testing';

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@
  */
 
 let cosmosURL;
+let chainID;
 
 if (process.env.REACT_APP_COSMOS_URL) {
   cosmosURL = process.env.REACT_APP_COSMOS_URL;
@@ -15,4 +16,10 @@ if (process.env.REACT_APP_COSMOS_URL) {
 
 export const COSMOS_URL = cosmosURL;
 
-export const CHAIN_ID = 'testing';
+if (process.env.REACT_APP_CHAIN_ID) {
+  chainID = process.env.REACT_APP_CHAIN_ID;
+} else {
+  chainID = 'testing';
+}
+
+export const CHAIN_ID = chainID;

--- a/src/features/api/APIConnect.js
+++ b/src/features/api/APIConnect.js
@@ -1,22 +1,52 @@
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Box } from '@material-ui/core';
+import { useSelector, useDispatch } from 'react-redux';
+import { Box, Button, Typography} from '@material-ui/core';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab/';
 import { TrendingFlat, AttachMoney } from '@material-ui/icons';
-import { selectIsPosted } from './apiSlice';
+import { idle, txState, selectTxState, selectTxError, selectTxErrorState } from './apiSlice';
 import { Transfer } from './Transfer';
 import { CreateCDP } from './CreateCDP';
+import { Loading } from '../common/Loading';
+
+const txMessage = {
+  [txState.PREPARING]: 'Preparing',
+  [txState.SIGNING]: 'Signing',
+  [txState.BROADCASTING]: 'Broadcasting',
+  [txState.CONFIRMING]: 'Confirming',
+}
+
+function txIsIdle(state) {
+  return state === txState.IDLE;
+}
+
+function txInProgress(state) {
+  return state !== txState.IDLE &&
+    state !== txState.ERRORED &&
+    state !== txState.COMPLETED
+}
+
+function txErrored(state) {
+  return state === txState.ERRORED;
+}
+
+function txCompleted(state) {
+  return state === txState.COMPLETED;
+}
 
 export function APIConnect({ cosmosAPI }) {
+  const dispatch = useDispatch();
   const [view, setView] = useState('transfer');
-  const posted = useSelector(selectIsPosted);
+  const currentTxState = useSelector(selectTxState);
+  const txError = useSelector(selectTxError);
+  const txErrorState = useSelector(selectTxErrorState);
+
   const handleChange = (event, nextView) => {
     setView(nextView);
   };
 
   let component;
 
-  if(!posted) {
+  if (txIsIdle(currentTxState)) {
     switch(view) {
       case 'transfer':
         component = <Transfer cosmosAPI={cosmosAPI} />
@@ -27,25 +57,65 @@ export function APIConnect({ cosmosAPI }) {
       default:
         break;
     }
-  } else {
+  } else if (txInProgress(currentTxState)) {
+    component = <Loading message={txMessage[currentTxState] + '...'} />
+  } else if (txErrored(currentTxState)) {
     component = (
       <Box paddingTop={1}>
-        <p>Tx sent</p>
+        <Typography variant="h4" color="error">
+          Error while { txErrorState }
+        </Typography>
+        <Typography variant="h5" component="p" color="error">
+          { txError }
+        </Typography>
+        <Box width="227px" margin="auto" paddingTop={1}>
+        <Button
+            variant="contained"
+            color="secondary"
+            size="large"
+            fullWidth={true}
+            onClick={() => dispatch(idle())}
+          >
+            Back
+          </Button>
+        </Box>
+      </Box>
+    )
+  } else if (txCompleted(currentTxState)) {
+    component = (
+      <Box paddingTop={1}>
+        <Typography variant="h5" component="p" color="secondary">
+          Transaction Confirmed!
+        </Typography>
+      <Box width="227px" margin="auto" paddingTop={1}>
+        <Button
+            variant="contained"
+            color="secondary"
+            size="large"
+            fullWidth={true}
+            onClick={() => dispatch(idle())}
+          >
+          Back
+        </Button>
+      </Box>
       </Box>
     )
   }
 
   return (
     <Box>
-      <ToggleButtonGroup orientation="horizontal" value={view} exclusive onChange={handleChange}>
-      <ToggleButton value="transfer" aria-label="transfer">
-        <TrendingFlat />
-      </ToggleButton>
-      <ToggleButton value="createCDP" aria-label="createCDP">
-        <AttachMoney />
-      </ToggleButton>
-      </ToggleButtonGroup>
+      { txIsIdle(currentTxState) &&
+        <ToggleButtonGroup orientation="horizontal" value={view} exclusive onChange={handleChange}>
+        <ToggleButton value="transfer" aria-label="transfer">
+          <TrendingFlat />
+        </ToggleButton>
+        <ToggleButton value="createCDP" aria-label="createCDP">
+          <AttachMoney />
+        </ToggleButton>
+        </ToggleButtonGroup>
+      }
       {component}
     </Box>
   )
 }
+

--- a/src/features/api/APIConnect.js
+++ b/src/features/api/APIConnect.js
@@ -1,73 +1,50 @@
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Box } from '@material-ui/core';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab/';
 import { TrendingFlat, AttachMoney } from '@material-ui/icons';
-
-import { Loading } from '../common/Loading';
-import { initApiAsync, selectIsLoaded, selectIsPosted} from './apiSlice';
+import { selectIsPosted } from './apiSlice';
 import { Transfer } from './Transfer';
 import { CreateCDP } from './CreateCDP';
 
 export function APIConnect({ cosmosAPI }) {
-  const dispatch = useDispatch();
-
   const [view, setView] = useState('transfer');
-
-  const loaded = useSelector(selectIsLoaded);
   const posted = useSelector(selectIsPosted);
-
   const handleChange = (event, nextView) => {
     setView(nextView);
   };
 
-  useEffect(() => {
-    dispatch(initApiAsync(cosmosAPI));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  let toggle;
   let component;
-  switch(loaded) {
-    case false:
-        component = <Loading message="Initializing..."/>
-        break
-    case true:
-        toggle = (
-          <ToggleButtonGroup orientation="horizontal" value={view} exclusive onChange={handleChange}>
-          <ToggleButton value="transfer" aria-label="transfer">
-            <TrendingFlat />
-          </ToggleButton>
-          <ToggleButton value="createCDP" aria-label="createCDP">
-            <AttachMoney />
-          </ToggleButton>
-          </ToggleButtonGroup>
-        )
-        if(!posted) {
-          switch(view) {
-            case 'transfer':
-              component = <Transfer cosmosAPI={cosmosAPI} />
-              break;
-            case 'createCDP':
-              component = <CreateCDP cosmosAPI={cosmosAPI} />
-              break;
-          }
-        } else {
-          component = (
-            <Box paddingTop={1}>
-              <p>Tx sent</p>
-            </Box>
-          )
-        }
-        break
-      default:
-        break
-    }
 
-  // Render
+  if(!posted) {
+    switch(view) {
+      case 'transfer':
+        component = <Transfer cosmosAPI={cosmosAPI} />
+        break;
+      case 'createCDP':
+        component = <CreateCDP cosmosAPI={cosmosAPI} />
+        break;
+      default:
+        break;
+    }
+  } else {
+    component = (
+      <Box paddingTop={1}>
+        <p>Tx sent</p>
+      </Box>
+    )
+  }
+
   return (
     <Box>
-      {toggle}
+      <ToggleButtonGroup orientation="horizontal" value={view} exclusive onChange={handleChange}>
+      <ToggleButton value="transfer" aria-label="transfer">
+        <TrendingFlat />
+      </ToggleButton>
+      <ToggleButton value="createCDP" aria-label="createCDP">
+        <AttachMoney />
+      </ToggleButton>
+      </ToggleButtonGroup>
       {component}
     </Box>
   )

--- a/src/features/api/APIConnect.js
+++ b/src/features/api/APIConnect.js
@@ -1,75 +1,74 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Button } from '@material-ui/core';
-import { initApiAsync, postMsgAsync, selectIsLoaded, selectIsPosted} from './apiSlice';
+import { Box } from '@material-ui/core';
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab/';
+import { TrendingFlat, AttachMoney } from '@material-ui/icons';
+
 import { Loading } from '../common/Loading';
+import { initApiAsync, selectIsLoaded, selectIsPosted} from './apiSlice';
+import { Transfer } from './Transfer';
+import { CreateCDP } from './CreateCDP';
 
 export function APIConnect({ cosmosAPI }) {
   const dispatch = useDispatch();
 
+  const [view, setView] = useState('transfer');
+
   const loaded = useSelector(selectIsLoaded);
   const posted = useSelector(selectIsPosted);
 
-  let [recipient, setRecipient] = useState('');
-  let [denom, setDenom] = useState('');
-  let [amount, setAmount] = useState('');
+  const handleChange = (event, nextView) => {
+    setView(nextView);
+  };
 
   useEffect(() => {
     dispatch(initApiAsync(cosmosAPI));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  let toggle;
   let component;
   switch(loaded) {
     case false:
-      if(!posted) {
         component = <Loading message="Initializing..."/>
-      } else {
-        component = (
-        <Box paddingTop={1}>
-          <p>Tx sent</p>
-        </Box>
-        )
-      }
-      break;
+        break
     case true:
-      component = (
-        <Box paddingTop='1rem'>
-          <p>Recipient</p>
-          <input
-            value={recipient}
-            onChange={e => setRecipient(e.target.value)}
-          />
-          <p>Denom</p>
-          <input
-            value={denom}
-            onChange={e => setDenom(e.target.value)}
-          />
-          <p>Amount</p>
-          <input
-            value={amount}
-            onChange={e => setAmount(e.target.value)}
-          />
-          <br/>
-          <br/>
-          <Button
-            variant="outlined"
-            color="secondary"
-            size="large"
-            onClick={() => dispatch(postMsgAsync(cosmosAPI, recipient, denom, amount))}>
-              Send
-          </Button>
-        </Box>
-      )
-      break;
-    default:
-      break;
+        toggle = (
+          <ToggleButtonGroup orientation="horizontal" value={view} exclusive onChange={handleChange}>
+          <ToggleButton value="transfer" aria-label="transfer">
+            <TrendingFlat />
+          </ToggleButton>
+          <ToggleButton value="createCDP" aria-label="createCDP">
+            <AttachMoney />
+          </ToggleButton>
+          </ToggleButtonGroup>
+        )
+        if(!posted) {
+          switch(view) {
+            case 'transfer':
+              component = <Transfer cosmosAPI={cosmosAPI} />
+              break;
+            case 'createCDP':
+              component = <CreateCDP cosmosAPI={cosmosAPI} />
+              break;
+          }
+        } else {
+          component = (
+            <Box paddingTop={1}>
+              <p>Tx sent</p>
+            </Box>
+          )
+        }
+        break
+      default:
+        break
     }
 
-    // Render
-    return (
-      <Box>
-        {component}
-      </Box>
-    )
+  // Render
+  return (
+    <Box>
+      {toggle}
+      {component}
+    </Box>
+  )
 }

--- a/src/features/api/CosmosAPI.js
+++ b/src/features/api/CosmosAPI.js
@@ -1,83 +1,174 @@
-import Cosmos, {createSignMessage} from '@lunie/cosmos-api'
+import Kava from '@kava-labs/javascript-sdk';
+import { toCanonicalJSONString, bytesToBase64 } from '@tendermint/belt';
+//const sender = await cosmosAPI.getAccountAddress();
+  //const coins = Kava.utils.formatCoins(amount, denom);
+  //const msgSend = Kava.msg.newMsgSend(sender, recipient, coins);
 
+  //// NOTE: msgSend's json is formatted as:
+  //// {
+  ////   type: 'cosmos-sdk/MsgSend',
+  ////   value: {
+  ////     from_address: sender,
+  ////     to_address: recipient,
+  ////     amount: [{amount: String(amount), denom: String(denom)}],
+  ////   }
+  //// }
+
+  //const fee = { amount: [], gas: `200000` };
+  //const stdTx = Kava.msg.newStdTx([msgSend], fee, '200000');
+
+  //const signInfo = await cosmosAPI.prepareSignInfo();
+  //const signedTx = await cosmosAPI.signTx(stdTx, signInfo)
+  //console.log("signedTx:", signedTx);
+
+  //// TODO: broadcast signed transaction:
+  //// await cosmosAPI.broadcastTx(signedTx);
+
+  //// Sign and broadcast the transaction
+  //// await cosmosAPI.broadcast(msgSend);
+  //// dispatch(posted());
 export class CosmosAPI {
   constructor(url, chainID, ledger) {
     this._url = url;
     this._chainID = chainID;
     this._ledger = ledger;
-    this._cosmosAPI = null;
     return this
   }
 
-  async init() {
-    this._cosmosAPI = new Cosmos(this._url, this._chainID);
-    return this._cosmosAPI;
-  }
+  async MsgSend(recipient, denom, amount) {
+    // Get Ledger Kava Address
+    const sender = await this._ledger.getAddress();
+    // Format coins for MsgSend JSON
+    const coins = Kava.utils.formatCoins(amount, denom);
+    // Create Message to include in tx
+    // {
+    //   type: 'cosmos-sdk/MsgSend',
+    //   value: {
+    //     from_address: sender,
+    //     to_address: recipient,
+    //     amount: [{amount: String(amount), denom: String(denom)}],
+    //   }
+    // }
+    const msgSend = Kava.msg.newMsgSend(sender, recipient, coins);
+    // Create stdTx using Kava SDK fee and gas defaults
+    const stdTx = Kava.msg.newStdTx([msgSend])
 
-  async getAccountAddress() {
-    return await this._ledger.getAddress();
-  }
+    const accountResponse = await fetch(this._url + '/auth/accounts/' + sender);
+    const accountData = await accountResponse.json()
 
-  async getBlock(height) {
-    return await this._cosmosAPI.get.block(height)
-  }
+    const account_number = accountData.result.value.account_number;
+    const sequence = accountData.result.value.sequence;
 
-  async getAccount(addr) {
-    return await this._cosmosAPI.get.account(addr)
-  }
-
-  async prepareSignInfo() {
-    // Fetch and parse account meta data 
-    const acc = await this.getAccount(await this.getAccountAddress());
-
-    let accNum;
-    let seqNum;
-    if(acc) {
-      accNum = acc.account_number;
-      seqNum = acc.sequence;
-    }
-    if (!(accNum || seqNum)) {
-      console.log('Error: account number or sequence number from rest server are undefined');
-    }
-
-    // Package signing info
-    const signInfo = {
+    // object to sign
+    const signTx = {
+      account_number: account_number,
       chain_id: this._chainID,
-      account_number: accNum,
-      sequence: seqNum,
+      fee: stdTx.value.fee,
+      memo: stdTx.value.memo,
+      msgs: stdTx.value.msg,
+      sequence: sequence,
+    }
+
+    console.log(signTx);
+
+    // sort and format to json string for ledger signing
+    const signMsg = toCanonicalJSONString(signTx);
+
+    // get pubkey and signature from ledger
+    const pubKey = await this._ledger.getPubKey();
+    const signature = await this._ledger.sign(signMsg);
+
+    const signedTx = {
+      msg: stdTx.value.msg,
+      fee: stdTx.value.fee,
+      memo: stdTx.value.memo,
+      signatures: [
+        {
+          signature: bytesToBase64(signature),
+          pub_key: {
+            type: 'tendermint/PubKeySecp256k1',
+            value: bytesToBase64(pubKey)
+          }
+        }
+      ]
     };
 
-    return signInfo;
+    console.log(signedTx);
+
+    // broadcast
+    const response = await fetch(this._url + '/txs', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        tx: signedTx,
+        mode: 'sync'
+      })
+    });
+
+    const data = await response.json();
+
+    console.log(data);
   }
 
-  async signTx(tx, meta) {
-    // TODO: create sign msg to replace createSignMessage
-    // const signMsg = createSignMsg(tx, meta);
 
-    const seq = meta.sequence;
-    const acc = meta.account_number;
-    const id = meta.chain_id;
-    const signMessage = createSignMessage(tx, { seq, acc, id });
+  //async getAccount(addr) {
+  //  return await this._cosmosAPI.get.account(addr)
+  //}
 
-    // TODO: create signature using ledger
-    // const signature = createSignature(signMsg, keyPair);
-    // return signature
-    return signMessage
-  }
+  //async prepareSignInfo() {
+  //  // Fetch and parse account meta data 
+  //  const acc = await this.getAccount(await this.getAccountAddress());
 
-  async broadcast(msg) {
-    const signer = this._ledger.getSigner();
-    return await this.send({ gas: '250000', memo: 'kava test tx' }, msg, signer);
-  }
+  //  let accNum;
+  //  let seqNum;
+  //  if(acc) {
+  //    accNum = acc.account_number;
+  //    seqNum = acc.sequence;
+  //  }
+  //  if (!(accNum || seqNum)) {
+  //    console.log('Error: account number or sequence number from rest server are undefined');
+  //  }
 
-  async send({ gas, gasPrices, memo = undefined }, message, signer) {
-    const senderAddress = await this.getAccountAddress();
-    return await this._cosmosAPI.send(senderAddress, { gas, gasPrices, memo }, message, signer)
-  }
+  //  // Package signing info
+  //  const signInfo = {
+  //    chain_id: this._chainID,
+  //    account_number: accNum,
+  //    sequence: seqNum,
+  //  };
 
-  async simulate({ memo = undefined }, message) {
-    const senderAddress = await this.getAccountAddress();
-    return await this._cosmosAPI.simulate(senderAddress, { message, memo });
-  }
+  //  return signInfo;
+  //}
+
+  //async signTx(tx, meta) {
+  //  // TODO: create sign msg to replace createSignMessage
+  //  // const signMsg = createSignMsg(tx, meta);
+
+  //  const seq = meta.sequence;
+  //  const acc = meta.account_number;
+  //  const id = meta.chain_id;
+  //  const signMessage = createSignMessage(tx, { seq, acc, id });
+
+  //  // TODO: create signature using ledger
+  //  // const signature = createSignature(signMsg, keyPair);
+  //  // return signature
+  //  return signMessage
+  //}
+
+  //async broadcast(msg) {
+  //  const signer = this._ledger.getSigner();
+  //  return await this.send({ gas: '250000', memo: 'kava test tx' }, msg, signer);
+  //}
+
+  //async send({ gas, gasPrices, memo = undefined }, message, signer) {
+  //  const senderAddress = await this.getAccountAddress();
+  //  return await this._cosmosAPI.send(senderAddress, { gas, gasPrices, memo }, message, signer)
+  //}
+
+  //async simulate({ memo = undefined }, message) {
+  //  const senderAddress = await this.getAccountAddress();
+  //  return await this._cosmosAPI.simulate(senderAddress, { message, memo });
+  //}
 
 }

--- a/src/features/api/CosmosAPI.js
+++ b/src/features/api/CosmosAPI.js
@@ -1,24 +1,18 @@
-import Cosmos from "@lunie/cosmos-api"
-
-// TODO: put in config
-const chainID = "testing"
+import Cosmos, {createSignMessage} from '@lunie/cosmos-api'
 
 export class CosmosAPI {
-  constructor(url, ledger) {
+  constructor(url, chainID, ledger) {
     this._url = url;
+    this._chainID = chainID;
     this._ledger = ledger;
     this._cosmosAPI = null;
     return this
   }
 
   async init() {
-    this._cosmosAPI = new Cosmos(this._url, chainID);
+    this._cosmosAPI = new Cosmos(this._url, this._chainID);
     return this._cosmosAPI;
   }
-
-  // -----------------------------------
-  //            HTTP get
-  // -----------------------------------
 
   async getAccountAddress() {
     return await this._ledger.getAddress();
@@ -32,17 +26,48 @@ export class CosmosAPI {
     return await this._cosmosAPI.get.account(addr)
   }
 
-  // -----------------------------------
-  //            HTTP options
-  // -----------------------------------
+  async prepareSignInfo() {
+    // Fetch and parse account meta data 
+    const acc = await this.getAccount(await this.getAccountAddress());
+
+    let accNum;
+    let seqNum;
+    if(acc) {
+      accNum = acc.account_number;
+      seqNum = acc.sequence;
+    }
+    if (!(accNum || seqNum)) {
+      console.log('Error: account number or sequence number from rest server are undefined');
+    }
+
+    // Package signing info
+    const signInfo = {
+      chain_id: this._chainID,
+      account_number: accNum,
+      sequence: seqNum,
+    };
+
+    return signInfo;
+  }
+
+  async signTx(tx, meta) {
+    // TODO: create sign msg to replace createSignMessage
+    // const signMsg = createSignMsg(tx, meta);
+
+    const seq = meta.sequence;
+    const acc = meta.account_number;
+    const id = meta.chain_id;
+    const signMessage = createSignMessage(tx, { seq, acc, id });
+
+    // TODO: create signature using ledger
+    // const signature = createSignature(signMsg, keyPair);
+    // return signature
+    return signMessage
+  }
 
   async broadcast(msg) {
-    // TODO: Replace gas amount with 'gasEstimate'
-    // const gasEstimate = await this.simulate({}, msg)
-    // console.log("gasEstimate:", gasEstimate)
-
     const signer = this._ledger.getSigner();
-    return await this.send({ gas: '250000' }, msg, signer);
+    return await this.send({ gas: '250000', memo: 'kava test tx' }, msg, signer);
   }
 
   async send({ gas, gasPrices, memo = undefined }, message, signer) {
@@ -54,4 +79,5 @@ export class CosmosAPI {
     const senderAddress = await this.getAccountAddress();
     return await this._cosmosAPI.simulate(senderAddress, { message, memo });
   }
+
 }

--- a/src/features/api/CosmosAPI.js
+++ b/src/features/api/CosmosAPI.js
@@ -56,8 +56,8 @@ export class CosmosAPI {
     const accountResponse = await fetch(this._url + '/auth/accounts/' + sender);
     const accountData = await accountResponse.json()
 
-    const account_number = accountData.result.value.account_number;
-    const sequence = accountData.result.value.sequence;
+    const account_number = accountData.result.value.account_number.toString();
+    const sequence = accountData.result.value.sequence.toString();
 
     // object to sign
     const signTx = {
@@ -66,7 +66,7 @@ export class CosmosAPI {
       fee: stdTx.value.fee,
       memo: stdTx.value.memo,
       msgs: stdTx.value.msg,
-      sequence: sequence,
+      sequence: sequence
     }
 
     console.log(signTx);

--- a/src/features/api/CreateCDP.js
+++ b/src/features/api/CreateCDP.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Box, Button, TextField } from '@material-ui/core';
+import { postMsgCreateCdpAsync} from './apiSlice';
+
+export function CreateCDP({ cosmosAPI }) {
+  const dispatch = useDispatch();
+
+  let [collateralDenom, setCollateralDenom] = useState('');
+  let [collateralAmount, setCollateralAmount] = useState('');
+  let [principalDenom, setPrincipalDenom] = useState('');
+  let [principalAmount, setPrincipalAmount] = useState('');
+
+  return (
+    <Box paddingTop='1rem'>
+    <Box display="flex" paddingTop='1rem' flexDirection="row">
+        <TextField
+            id="input-collateral-denom"
+            label="Collateral Denom"
+            style={{ margin: 8 }}
+            placeholder="bnb"
+            margin="normal"
+            InputLabelProps={{
+            value: collateralDenom,
+            shrink: true,
+            onChange: e => setCollateralDenom(e.target.value)
+            }}
+        />
+        <TextField
+            id="input-collateral-amount"
+            label="Collateral Amount"
+            style={{ margin: 8 }}
+            placeholder="100"
+            margin="normal"
+            InputLabelProps={{
+            value: collateralAmount,
+            shrink: true,
+            onChange: e => setCollateralAmount(e.target.value)
+            }}
+        />    
+    </Box>
+    <Box display="flex" paddingTop='1rem' flexDirection="row">
+        <TextField
+            id="input-principal-denom"
+            label="Principal Denom"
+            style={{ margin: 8 }}
+            placeholder="usdx"
+            margin="normal"
+            InputLabelProps={{
+            value: principalDenom,
+            shrink: true,
+            onChange: e => setPrincipalDenom(e.target.value)
+            }}
+        />
+        <TextField
+            id="input-principal-amount"
+            label="Principal Amount"
+            style={{ margin: 8 }}
+            placeholder="100"
+            margin="normal"
+            InputLabelProps={{
+            value: principalAmount,
+            shrink: true,
+            onChange: e => setPrincipalAmount(e.target.value)
+            }}
+        />    
+    </Box>    
+    <br/>
+    <Button
+        variant="outlined"
+        color="secondary"
+        size="large"
+        onClick={() => dispatch(
+        postMsgCreateCdpAsync(
+            cosmosAPI,
+            collateralDenom,
+            collateralAmount,
+            principalDenom,
+            principalAmount)
+        )}>
+        Create CDP
+    </Button>
+    </Box>
+    )
+}

--- a/src/features/api/CreateCDP.js
+++ b/src/features/api/CreateCDP.js
@@ -63,23 +63,26 @@ export function CreateCDP({ cosmosAPI }) {
             value: principalAmount,
             shrink: true
             }}
-        />    
-    </Box>    
+        />
+    </Box>
     <br/>
-    <Button
-        variant="outlined"
-        color="secondary"
-        size="large"
-        onClick={() => dispatch(
-        postMsgCreateCdpAsync(
-            cosmosAPI,
-            collateralDenom,
-            collateralAmount,
-            principalDenom,
-            principalAmount)
-        )}>
-        Create CDP
-    </Button>
+    <Box width="227px" margin="auto">
+      <Button
+          variant="contained"
+          color="secondary"
+          size="large"
+          fullWidth={true}
+          onClick={() => dispatch(
+          postMsgCreateCdpAsync(
+              cosmosAPI,
+              collateralDenom,
+              collateralAmount,
+              principalDenom,
+              principalAmount)
+          )}>
+          Create CDP
+        </Button>
+      </Box>
     </Box>
     )
 }

--- a/src/features/api/CreateCDP.js
+++ b/src/features/api/CreateCDP.js
@@ -20,10 +20,10 @@ export function CreateCDP({ cosmosAPI }) {
             style={{ margin: 8 }}
             placeholder="bnb"
             margin="normal"
+            onChange={e => setCollateralDenom(e.target.value)}
             InputLabelProps={{
             value: collateralDenom,
-            shrink: true,
-            onChange: e => setCollateralDenom(e.target.value)
+            shrink: true
             }}
         />
         <TextField
@@ -32,10 +32,10 @@ export function CreateCDP({ cosmosAPI }) {
             style={{ margin: 8 }}
             placeholder="100"
             margin="normal"
+            onChange={e => setCollateralAmount(e.target.value)}
             InputLabelProps={{
             value: collateralAmount,
-            shrink: true,
-            onChange: e => setCollateralAmount(e.target.value)
+            shrink: true
             }}
         />    
     </Box>
@@ -46,10 +46,10 @@ export function CreateCDP({ cosmosAPI }) {
             style={{ margin: 8 }}
             placeholder="usdx"
             margin="normal"
+            onChange={e => setPrincipalDenom(e.target.value)}
             InputLabelProps={{
             value: principalDenom,
-            shrink: true,
-            onChange: e => setPrincipalDenom(e.target.value)
+            shrink: true
             }}
         />
         <TextField
@@ -58,10 +58,10 @@ export function CreateCDP({ cosmosAPI }) {
             style={{ margin: 8 }}
             placeholder="100"
             margin="normal"
+            onChange={e => setPrincipalAmount(e.target.value)}
             InputLabelProps={{
             value: principalAmount,
-            shrink: true,
-            onChange: e => setPrincipalAmount(e.target.value)
+            shrink: true
             }}
         />    
     </Box>    

--- a/src/features/api/Transfer.js
+++ b/src/features/api/Transfer.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Box, Button, TextField } from '@material-ui/core';
+import { postMsgSendAsync} from './apiSlice';
+
+export function Transfer({ cosmosAPI }) {
+  const dispatch = useDispatch();
+
+  let [recipient, setRecipient] = useState('');
+  let [denom, setDenom] = useState('');
+  let [amount, setAmount] = useState('');
+
+  return (
+    <Box paddingTop='1rem'>
+        <TextField
+        id="input-recipient"
+        label="Recipient"
+        style={{ margin: 8 }}
+        placeholder="kava834au91..."
+        fullWidth
+        margin="normal"
+        onChange={e => setRecipient(e.target.value)}
+        InputLabelProps={{
+            value: recipient,
+            shrink: true
+        }}
+        />
+        <Box display="flex" paddingTop='1rem' flexDirection="row">
+            <TextField
+                id="input-denom"
+                label="Denom"
+                style={{ margin: 8 }}
+                placeholder="bnb"
+                margin="normal"
+                onChange={e => setDenom(e.target.value)}
+                InputLabelProps={{
+                value: denom,
+                shrink: true
+                }}
+            />
+            <TextField
+                id="input-amount"
+                label="Amount"
+                style={{ margin: 8 }}
+                placeholder="100"
+                margin="normal"
+                onChange={e => setAmount(e.target.value)}
+                InputLabelProps={{
+                value: amount,
+                shrink: true
+                }}
+            />
+        </Box>
+        <br/>
+        <Button
+            variant="outlined"
+            color="secondary"
+            size="large"
+            onClick={() => dispatch(postMsgSendAsync(cosmosAPI, recipient, denom, amount))}>
+            Transfer
+        </Button>
+    </Box>
+    )
+}

--- a/src/features/api/Transfer.js
+++ b/src/features/api/Transfer.js
@@ -52,13 +52,16 @@ export function Transfer({ cosmosAPI }) {
             />
         </Box>
         <br/>
-        <Button
-            variant="outlined"
-            color="secondary"
-            size="large"
-            onClick={() => dispatch(postMsgSendAsync(cosmosAPI, recipient, denom, amount))}>
-            Transfer
-        </Button>
+        <Box width="227px" margin="auto">
+          <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              fullWidth={true}
+              onClick={() => dispatch(postMsgSendAsync(cosmosAPI, recipient, denom, amount))}>
+              Transfer
+          </Button>
+        </Box>
     </Box>
     )
 }

--- a/src/features/api/apiSlice.js
+++ b/src/features/api/apiSlice.js
@@ -1,61 +1,22 @@
 import { createSlice } from '@reduxjs/toolkit';
-import Kava from '@kava-labs/javascript-sdk';
 
 export const apiSlice = createSlice({
   name: 'api',
   initialState: {
-    isLoaded: false,
     isPosted: false,
   },
   reducers: {
-    connected: state => {
-      state.isLoaded = true;
-    },
     posted: state => {
       state.isPosted = true;
     }
   }
 });
 
-export const { connected, posted } = apiSlice.actions;
-
-export const initApiAsync = cosmosAPI => async dispatch => {
-  try {
-    await cosmosAPI.init()
-    dispatch(connected())
-  } catch (e) {
-    console.log("initialization error:", e.toString())
-  }
-}
+export const { posted } = apiSlice.actions;
 
 export const postMsgSendAsync = (cosmosAPI, recipient, denom, amount) => async dispatch => {
-  const sender = await cosmosAPI.getAccountAddress();
-  const coins = Kava.utils.formatCoins(amount, denom);
-  const msgSend = Kava.msg.newMsgSend(sender, recipient, coins);
-
-  // NOTE: msgSend's json is formatted as:
-  // {
-  //   type: 'cosmos-sdk/MsgSend',
-  //   value: {
-  //     from_address: sender,
-  //     to_address: recipient,
-  //     amount: [{amount: String(amount), denom: String(denom)}],
-  //   }
-  // }
-
-  const fee = { amount: [], gas: `200000` };
-  const stdTx = Kava.msg.newStdTx([msgSend], fee, '200000');
-
-  const signInfo = await cosmosAPI.prepareSignInfo();
-  const signedTx = await cosmosAPI.signTx(stdTx, signInfo)
-  console.log("signedTx:", signedTx);
-
-  // TODO: broadcast signed transaction:
-  // await cosmosAPI.broadcastTx(signedTx);
-
-  // Sign and broadcast the transaction
-  // await cosmosAPI.broadcast(msgSend);
-  // dispatch(posted());
+  await cosmosAPI.MsgSend(recipient, denom, amount);
+  dispatch(posted())
 }
 
 export const postMsgCreateCdpAsync = (
@@ -65,17 +26,16 @@ export const postMsgCreateCdpAsync = (
   principalDenom,
   principalAmount
 ) => async dispatch => {
-  const sender = await cosmosAPI.getAccountAddress();
-  const collateral = Kava.utils.formatCoins(collateralAmount, collateralDenom);
-  const principal = Kava.utils.formatCoins(principalAmount, principalDenom);
-  const msg = Kava.msg.newMsgCreateCDP(sender, principal, collateral);
+  //const sender = await cosmosAPI.getAccountAddress();
+  //const collateral = Kava.utils.formatCoins(collateralAmount, collateralDenom);
+  //const principal = Kava.utils.formatCoins(principalAmount, principalDenom);
+  //const msg = Kava.msg.newMsgCreateCDP(sender, principal, collateral);
 
-  // Sign and broadcast the transaction
-  await cosmosAPI.broadcast(msg);
+  //// Sign and broadcast the transaction
+  //await cosmosAPI.broadcast(msg);
   dispatch(posted());
 }
 
-export const selectIsLoaded = state => state.api.isLoaded;
 export const selectIsPosted = state => state.api.isPosted;
 
 export default apiSlice.reducer;

--- a/src/features/api/apiSlice.js
+++ b/src/features/api/apiSlice.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+import Kava from '@kava-labs/javascript-sdk';
 
 export const apiSlice = createSlice({
   name: 'api',
@@ -27,18 +28,30 @@ export const initApiAsync = cosmosAPI => async dispatch => {
   }
 }
 
-export const postMsgAsync = (cosmosAPI, recipient, denom, amount) => async dispatch => {
+export const postMsgSendAsync = (cosmosAPI, recipient, denom, amount) => async dispatch => {
   const sender = await cosmosAPI.getAccountAddress();
-  const acc = await cosmosAPI.getAccount(sender);
-  console.log("Ledger wallet account:", acc)
-
-  // Build the Send msg
-  const msg = cosmosAPI.MsgSend(sender, recipient, denom, amount);
-  console.log("msg:", msg);
+  const coins = Kava.utils.formatCoins(amount, denom);
+  const msg = Kava.msg.newMsgSend(sender, recipient, coins);
 
   // Sign and broadcast the transaction
   await cosmosAPI.broadcast(msg);
+  dispatch(posted());
+}
 
+export const postMsgCreateCdpAsync = (
+  cosmosAPI,
+  collateralDenom,
+  collateralAmount,
+  principalDenom,
+  principalAmount
+) => async dispatch => {
+  const sender = await cosmosAPI.getAccountAddress();
+  const collateral = Kava.utils.formatCoins(collateralAmount, collateralDenom);
+  const principal = Kava.utils.formatCoins(principalAmount, principalDenom);
+  const msg = Kava.msg.newMsgCreateCDP(sender, principal, collateral);
+
+  // Sign and broadcast the transaction
+  await cosmosAPI.broadcast(msg);
   dispatch(posted());
 }
 

--- a/src/features/api/apiSlice.js
+++ b/src/features/api/apiSlice.js
@@ -31,11 +31,31 @@ export const initApiAsync = cosmosAPI => async dispatch => {
 export const postMsgSendAsync = (cosmosAPI, recipient, denom, amount) => async dispatch => {
   const sender = await cosmosAPI.getAccountAddress();
   const coins = Kava.utils.formatCoins(amount, denom);
-  const msg = Kava.msg.newMsgSend(sender, recipient, coins);
+  const msgSend = Kava.msg.newMsgSend(sender, recipient, coins);
+
+  // NOTE: msgSend's json is formatted as:
+  // {
+  //   type: 'cosmos-sdk/MsgSend',
+  //   value: {
+  //     from_address: sender,
+  //     to_address: recipient,
+  //     amount: [{amount: String(amount), denom: String(denom)}],
+  //   }
+  // }
+
+  const fee = { amount: [], gas: `200000` };
+  const stdTx = Kava.msg.newStdTx([msgSend], fee, '200000');
+
+  const signInfo = await cosmosAPI.prepareSignInfo();
+  const signedTx = await cosmosAPI.signTx(stdTx, signInfo)
+  console.log("signedTx:", signedTx);
+
+  // TODO: broadcast signed transaction:
+  // await cosmosAPI.broadcastTx(signedTx);
 
   // Sign and broadcast the transaction
-  await cosmosAPI.broadcast(msg);
-  dispatch(posted());
+  // await cosmosAPI.broadcast(msgSend);
+  // dispatch(posted());
 }
 
 export const postMsgCreateCdpAsync = (

--- a/src/features/ledger/LedgerConnect.js
+++ b/src/features/ledger/LedgerConnect.js
@@ -8,8 +8,8 @@ export function LedgerConnect({ ledger, errorMessage }) {
 
   return (
     <Box>
-      <Box paddingTop={1}>
-        <Button variant="outlined" color="secondary" size="large" onClick={() => dispatch(connectAsync(ledger))}>Connect Ledger</Button>
+      <Box margin="auto" paddingTop={1.5} width="227px">
+        <Button fullWidth={true} variant="contained" color="secondary" size="large" onClick={() => dispatch(connectAsync(ledger))}>Connect Ledger</Button>
       </Box>
       { errorMessage &&
         <Box paddingTop={1}>

--- a/src/features/ledger/ledger.js
+++ b/src/features/ledger/ledger.js
@@ -16,12 +16,28 @@ export class CosmosLedger {
   getSigner() {
     return async (signMessage) => {
       const publicKey = await this._ledger.getPubKey();
-      const signature = await this._ledger.sign(signMessage);
+      const signature = new BuffWrapper(await this._ledger.sign(signMessage));
 
       return {
         signature,
         publicKey
       }
     }
+  }
+}
+
+// NOTE: Gives Buffer compatible interface for Uint8Array
+// Cosmos API expects a toString('base64') method for
+// signature encoding
+class BuffWrapper {
+  constructor(sig) {
+    this._sig = sig;
+  }
+  toString(encoding) {
+    if (encoding !== 'base64') {
+      throw new Error('unknown encoding: ' + encoding);
+    }
+
+    return btoa(String.fromCharCode(...this._sig));
   }
 }

--- a/src/features/ledger/ledger.js
+++ b/src/features/ledger/ledger.js
@@ -13,31 +13,11 @@ export class CosmosLedger {
     return this._ledger.getCosmosAddress();
   }
 
-  getSigner() {
-    return async (signMessage) => {
-      const publicKey = await this._ledger.getPubKey();
-      const signature = new BuffWrapper(await this._ledger.sign(signMessage));
-
-      return {
-        signature,
-        publicKey
-      }
-    }
+  async getPubKey() {
+    return this._ledger.getPubKey();
   }
-}
 
-// NOTE: Gives Buffer compatible interface for Uint8Array
-// Cosmos API expects a toString('base64') method for
-// signature encoding
-class BuffWrapper {
-  constructor(sig) {
-    this._sig = sig;
-  }
-  toString(encoding) {
-    if (encoding !== 'base64') {
-      throw new Error('unknown encoding: ' + encoding);
-    }
-
-    return btoa(String.fromCharCode(...this._sig));
+  async sign(signMessage) {
+    return this._ledger.sign(signMessage);
   }
 }

--- a/src/features/ledger/ledger.js
+++ b/src/features/ledger/ledger.js
@@ -9,6 +9,10 @@ export class CosmosLedger {
     return this._ledger.connect();
   }
 
+  reset() {
+    this._ledger.cosmosApp = null;
+  }
+
   async getAddress() {
     return this._ledger.getCosmosAddress();
   }

--- a/src/features/ledger/ledgerSlice.js
+++ b/src/features/ledger/ledgerSlice.js
@@ -34,9 +34,18 @@ export const { connecting, connected, failed } = ledgerSlice.actions;
 export const connectAsync = ledger => async dispatch => {
   dispatch(connecting());
   try {
-    await ledger.connect()
+    await ledger.connect();
     dispatch(connected());
   } catch (e) {
+    // reset ledger on failure
+    //
+    // if the ledger failed to connect previously due to app not being open,
+    // connect will succeed a second time, allowing user to continue without
+    // cosmos app
+    //
+    // see https://github.com/luniehq/cosmos-ledger/blob/develop/src/cosmos-ledger.ts#L137
+    // where cosmos app is set before checking app open
+    ledger.reset();
     dispatch(failed(e.toString()));
   }
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,9 +5,11 @@ const theme = createMuiTheme({
   palette: {
     primary: {
       main: '#ff564f',
+      dark: '#ed3843',
     },
     secondary: {
-      main: '#3d35dc',
+      main: '#534eff',
+      dark: '#362dd1',
     },
     error: {
       main: red.A400,


### PR DESCRIPTION
Continued off of #4 

Fixes transaction signing for MsgSend and improves the UI to show progress, errors, and more closely match the branding guide.

Also, includes a fix for a bug that allowed getting around connect ledger without the cosmos app open.

I avoided the kava/javascript-sdk since webpack can't tree shake it.  I figured writing the messages and utils for now in this repo is quicker then refactoring the sdk build for webpack atm.

The last step of waiting for block inclusion is unfinished and commented out.